### PR TITLE
feat: add column-specific formatting support

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -71,3 +71,44 @@ fn test_full_width_characters() {
     assert!(output.contains("| りんご   | 100 |"));
     assert!(output.contains("| オレンジ | 200 |"));
 }
+
+#[test]
+fn test_column_formatting_basic() {
+    let input = "apple\t100\norange\t200";
+    let output = run_tablify_with_input(input, &["--format", "1:left,2:right"]);
+    assert!(output.contains("| apple  | 100 |"));
+    assert!(output.contains("| orange | 200 |"));
+}
+
+#[test]
+fn test_column_formatting_center() {
+    let input = "apple\t100\tgood\norange\t200\tbad";
+    let output = run_tablify_with_input(input, &["--format", "1:left,2:right,3:center"]);
+    assert!(output.contains("| apple  | 100 | good |"));
+    assert!(output.contains("| orange | 200 | bad  |"));
+}
+
+#[test]
+fn test_column_formatting_with_header() {
+    let input = "item\tprice\trating\napple\t100\tgood\norange\t200\tbad";
+    let output = run_tablify_with_input(input, &["--header", "--format", "1:left,2:right,3:center"]);
+    assert!(output.contains("| item   | price | rating |"));
+    assert!(output.contains("| apple  |   100 |  good  |"));
+    assert!(output.contains("| orange |   200 |  bad   |"));
+}
+
+#[test]
+fn test_column_formatting_partial_spec() {
+    let input = "apple\t100\tgood\norange\t200\tbad";
+    let output = run_tablify_with_input(input, &["--format", "2:right"]);
+    assert!(output.contains("| apple  | 100 | good |"));
+    assert!(output.contains("| orange | 200 | bad  |"));
+}
+
+#[test]
+fn test_column_formatting_with_full_width() {
+    let input = "りんご\t100\nオレンジ\t200";
+    let output = run_tablify_with_input(input, &["--format", "1:center,2:right"]);
+    assert!(output.contains("|  りんご  | 100 |"));
+    assert!(output.contains("| オレンジ | 200 |"));
+}


### PR DESCRIPTION
## Summary
• Add `--format` option to specify column alignment (left, right, center)
• Support format specification like `"1:left,2:right,3:center"` with unspecified columns defaulting to left alignment

## Test plan
- [x] All existing tests pass (6 original integration tests)
- [x] 5 new integration tests covering column formatting scenarios
- [x] Unicode-aware alignment tested with full-width characters
- [x] Code passes `cargo clippy` without warnings
- [x] Manual testing of CLI usage examples

🤖 Generated with [Claude Code](https://claude.ai/code)